### PR TITLE
iOS SDK: add dynamic completion redirect wiring for Hosted Link callbacks

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -165,7 +165,7 @@ When the Web SDK receives a `hosted_link_url` from the backend, the iOS wrapper 
 
 ### Required iOS configuration
 
-1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `completionRedirectUri`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-link-complete`). Your backend should set `completion_redirect_uri` for mobile to that (e.g. `com.yourapp.id://plaid-link-complete`). You can override by passing `completionRedirectUri: "custom-scheme"` if needed.
+1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `hostedLinkRedirectUri`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-complete`). Your backend should send that same value in the API payload field `completion_redirect_uri` (e.g. `com.yourapp.id://plaid-complete`). You can override by passing `hostedLinkRedirectUri: "custom-scheme"` if needed.
 
 2. **Register the URL scheme** in the app target (**Info → URL Types**). The scheme must match what the backend uses (your bundle ID when using the default, or your custom scheme). Example for bundle ID `com.yourapp.id`:
 
@@ -192,7 +192,7 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding",
-    // completionRedirectUri: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
+    // hostedLinkRedirectUri: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
     onEvent: { _ in },
     onSuccess: { _ in },
     onClose: { _ in },
@@ -204,25 +204,27 @@ WedgePayIOS(
 ### Plaid completion redirect URI – webapp config
 
 The iOS SDK builds an app-specific redirect URI at runtime:
-- If provided, uses `completionRedirectUri`.
+- If provided, uses `hostedLinkRedirectUri`.
 - Otherwise uses the first URL scheme registered in `CFBundleURLTypes`.
-- If unavailable, falls back to `Bundle.main.bundleIdentifier://plaid-link-complete`.
+- If unavailable, falls back to `Bundle.main.bundleIdentifier://plaid-complete`.
 
-The SDK then provides the redirect URI to the web app through supported channels:
+The SDK then provides the redirect URI and Hosted Link capabilities to the web app through supported channels:
 
 1. **Preferred (`setConfig`)** — Calls:
-   `WedgeSDK.setConfig({ completionRedirectUri: "<uri>" })`
+   `WedgeSDK.setConfig({ hostedLinkRedirectUri: "<uri>", platform: "ios", supportsHostedLink: true })`
 2. **Injected bridge object** — Sets `window.WedgeSDKIOS` with:
-   - `getCompletionRedirectUri(): string`
-   - `completionRedirectUri: string`
-   - `plaidCompletionRedirectUri: string`
+   - `getHostedLinkRedirectUri(): string`
+   - `hostedLinkRedirectUri: string`
+   - `platform: "ios"`
+   - `supportsHostedLink: true`
 3. **URL query params** — Appends all accepted keys:
-   - `completionRedirectUri`
-   - `plaidCompletionRedirectUri`
-   - `completion_redirect_uri`
-   - `plaid_completion_redirect_uri`
+   - `hostedLinkRedirectUri`
+   - `platform=ios`
+   - `supportsHostedLink=true`
 
 Query values are URL-encoded by `URLComponents`.
+
+Current Web SDK builds still accept legacy names for backward compatibility (`completionRedirectUri`, `getCompletionRedirectUri()`). New native integrations should use the hosted-link names above.
 
 ### Bridge contract
 
@@ -247,7 +249,7 @@ The Web SDK is responsible for registering `window.__hostedLinkComplete` and ref
 
 | Issue | Check |
 |-------|--------|
-| Callback never fires | Scheme in Info.plist and `completionRedirectUri` match backend `completion_redirect_uri`; session is not released early. |
+| Callback never fires | Scheme in Info.plist and `hostedLinkRedirectUri` match backend `completion_redirect_uri`; session is not released early. |
 | 404 / SPA reload | Hosted Link was opened in WKWebView; ensure only the native bridge opens it in ASWebAuthenticationSession. |
 | Multiple sessions | SDK blocks concurrent Hosted Link opens; wait for completion before opening again. |
 
@@ -262,7 +264,7 @@ public init(
     token: String,
     env: String,
     type: String = "onboarding",
-    completionRedirectUri: String? = nil,
+    hostedLinkRedirectUri: String? = nil,
     onEvent: @escaping (Any) -> Void,
     onSuccess: @escaping (String) -> Void,
     onClose: @escaping (Any) -> Void,
@@ -278,7 +280,7 @@ public init(
 | `token` | String | Required | Your onboarding token |
 | `env` | String | Required | Environment ("development", "integration", "sandbox", "production") |
 | `type` | String | "onboarding" | Flow type ("onboarding" or "funding") |
-| `completionRedirectUri` | String? | nil | If set, used as the full redirect URI. If nil, SDK derives it from app URL scheme (`CFBundleURLTypes`) and falls back to bundle identifier, then appends `://plaid-link-complete`. |
+| `hostedLinkRedirectUri` | String? | nil | If set, used as the full redirect URI. If nil, SDK derives it from app URL scheme (`CFBundleURLTypes`) and falls back to bundle identifier, then appends `://plaid-complete`. |
 | `onEvent` | Closure | Required | General event handler |
 | `onSuccess` | Closure | Required | Success completion handler |
 | `onClose` | Closure | Required | Close/cancel handler |
@@ -437,7 +439,7 @@ For questions about implementing the type parameter functionality:
 ### Version 1.1.0
 - ✨ **NEW**: Added `type` parameter support
 - ✨ **NEW**: Support for "onboarding" and "funding" flow types
-- ✨ **NEW**: Plaid Hosted Link via ASWebAuthenticationSession (`completionRedirectUri`)
+- ✨ **NEW**: Plaid Hosted Link via ASWebAuthenticationSession (`hostedLinkRedirectUri`)
 - 🔄 **ENHANCED**: URL construction includes type parameter
 - ✅ **BACKWARD COMPATIBLE**: Existing code continues to work
 - 📚 **DOCUMENTATION**: Comprehensive integration guide

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -165,7 +165,7 @@ When the Web SDK receives a `hosted_link_url` from the backend, the iOS wrapper 
 
 ### Required iOS configuration
 
-1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `plaidCallbackScheme`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-link-complete`). Your backend should set `completion_redirect_uri` for mobile to that (e.g. `com.yourapp.id://plaid-link-complete`). You can override by passing `plaidCallbackScheme: "custom-scheme"` if needed.
+1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `completionRedirectUri`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-link-complete`). Your backend should set `completion_redirect_uri` for mobile to that (e.g. `com.yourapp.id://plaid-link-complete`). You can override by passing `completionRedirectUri: "custom-scheme"` if needed.
 
 2. **Register the URL scheme** in the app target (**Info → URL Types**). The scheme must match what the backend uses (your bundle ID when using the default, or your custom scheme). Example for bundle ID `com.yourapp.id`:
 
@@ -192,7 +192,7 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding",
-    // plaidCallbackScheme: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
+    // completionRedirectUri: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
     onEvent: { _ in },
     onSuccess: { _ in },
     onClose: { _ in },
@@ -203,12 +203,26 @@ WedgePayIOS(
 
 ### Plaid completion redirect URI – webapp config
 
-The iOS SDK passes **`plaidCompletionRedirectUri`** to the webapp so it can use it when initializing and when creating the Plaid Hosted Link:
+The iOS SDK builds an app-specific redirect URI at runtime:
+- If provided, uses `completionRedirectUri`.
+- Otherwise uses the first URL scheme registered in `CFBundleURLTypes`.
+- If unavailable, falls back to `Bundle.main.bundleIdentifier://plaid-link-complete`.
 
-1. **Query param on initial load** — When the SDK loads the webapp URL, it appends **`plaidCompletionRedirectUri`** to the query string when a callback scheme is configured (bundle ID or `plaidCallbackScheme`). Value is the full redirect URI (e.g. `com.yourapp.id://complete` or `wedge.WedgeExample://complete`). The webapp can read this from the URL and pass it into **setConfig / initializeSDK** as `plaidCompletionRedirectUri` in the config object.
-2. **Injected after load** — The SDK also sets **`window.__wedgePlaidCompletionRedirectUri`** and **`window.__wedgePlaidCallbackScheme`** when the page loads, and includes them in the **iOSReady** event detail. The webapp can use these if it needs the value after load (e.g. to call setConfig with `plaidCompletionRedirectUri`).
+The SDK then provides the redirect URI to the web app through supported channels:
 
-If the webapp omits or sends an empty `plaidCompletionRedirectUri`, it may fall back to a legacy default (e.g. `wedge.WedgeExample://plaid-link-complete`). Use the same redirect URI you register with Plaid / your backend.
+1. **Preferred (`setConfig`)** — Calls:
+   `WedgeSDK.setConfig({ completionRedirectUri: "<uri>" })`
+2. **Injected bridge object** — Sets both `window.WedgeSDKiOS` and `window.WedgeSDKIOS` with:
+   - `getCompletionRedirectUri(): string`
+   - `completionRedirectUri: string`
+   - `plaidCompletionRedirectUri: string`
+3. **URL query params** — Appends all accepted keys:
+   - `completionRedirectUri`
+   - `plaidCompletionRedirectUri`
+   - `completion_redirect_uri`
+   - `plaid_completion_redirect_uri`
+
+Query values are URL-encoded by `URLComponents`.
 
 ### Bridge contract
 
@@ -216,7 +230,8 @@ If the webapp omits or sends an empty `plaidCompletionRedirectUri`, it may fall 
 - The iOS SDK opens that URL in **ASWebAuthenticationSession** (with `callbackURLScheme` and a presentation context). The session is retained until the callback runs.
 - When the provider redirects to your app (e.g. `myapp-plaid://complete?...`) or the user cancels, the iOS SDK calls **`window.__hostedLinkComplete(result)`** (no webview reload). Result:
   - `result.status`: `"success"` or `"cancel"`
-  - `result.callbackUrl`: the redirect URL on success (optional string).
+  - `result.callbackUrl`: the redirect URL on success (optional string)
+  - The SDK can also support sending a callback URL string containing a `status`/`result` query parameter if your web app consumes the string form.
 
 The Web SDK is responsible for registering `window.__hostedLinkComplete` and refreshing backend state on success or showing cancel/error UI on cancel.
 
@@ -232,7 +247,7 @@ The Web SDK is responsible for registering `window.__hostedLinkComplete` and ref
 
 | Issue | Check |
 |-------|--------|
-| Callback never fires | Scheme in Info.plist and `plaidCallbackScheme` match backend `completion_redirect_uri`; session is not released early. |
+| Callback never fires | Scheme in Info.plist and `completionRedirectUri` match backend `completion_redirect_uri`; session is not released early. |
 | 404 / SPA reload | Hosted Link was opened in WKWebView; ensure only the native bridge opens it in ASWebAuthenticationSession. |
 | Multiple sessions | SDK blocks concurrent Hosted Link opens; wait for completion before opening again. |
 
@@ -247,7 +262,7 @@ public init(
     token: String,
     env: String,
     type: String = "onboarding",
-    plaidCallbackScheme: String? = nil,
+    completionRedirectUri: String? = nil,
     onEvent: @escaping (Any) -> Void,
     onSuccess: @escaping (String) -> Void,
     onClose: @escaping (Any) -> Void,
@@ -263,7 +278,7 @@ public init(
 | `token` | String | Required | Your onboarding token |
 | `env` | String | Required | Environment ("development", "integration", "sandbox", "production") |
 | `type` | String | "onboarding" | Flow type ("onboarding" or "funding") |
-| `plaidCallbackScheme` | String? | nil | If set, used as the Plaid callback URL scheme. If nil, the app’s **bundle identifier** is used (e.g. `com.yourapp.id://complete`). |
+| `completionRedirectUri` | String? | nil | If set, used as the full redirect URI. If nil, SDK derives it from app URL scheme (`CFBundleURLTypes`) and falls back to bundle identifier, then appends `://plaid-link-complete`. |
 | `onEvent` | Closure | Required | General event handler |
 | `onSuccess` | Closure | Required | Success completion handler |
 | `onClose` | Closure | Required | Close/cancel handler |
@@ -397,7 +412,7 @@ func determineUserTypeFromContext(context: OnboardingContext) -> String {
 
 ## Version Information
 
-- **SDK Version**: 1.1.0
+- **SDK Version**: 1.2.0
 - **Minimum iOS Version**: 14.0+
 - **Swift Version**: 5.9+
 - **Xcode Version**: 15.0+
@@ -413,10 +428,16 @@ For questions about implementing the type parameter functionality:
 
 ## Changelog
 
+### Version 1.2.0
+- ✨ **NEW**: Runtime app-specific completion redirect URI resolution (explicit URI, URL scheme, or bundle ID fallback)
+- ✨ **NEW**: Webapp redirect propagation through `WedgeSDK.setConfig`, `window.WedgeSDKiOS/window.WedgeSDKIOS`, and supported URL query params
+- ✨ **NEW**: Hosted Link completion callback contract maintained via `window.__hostedLinkComplete(...)`
+- 📚 **DOCUMENTATION**: Updated integration guidance for redirect/channel requirements
+
 ### Version 1.1.0
 - ✨ **NEW**: Added `type` parameter support
 - ✨ **NEW**: Support for "onboarding" and "funding" flow types
-- ✨ **NEW**: Plaid Hosted Link via ASWebAuthenticationSession (`plaidCallbackScheme`)
+- ✨ **NEW**: Plaid Hosted Link via ASWebAuthenticationSession (`completionRedirectUri`)
 - 🔄 **ENHANCED**: URL construction includes type parameter
 - ✅ **BACKWARD COMPATIBLE**: Existing code continues to work
 - 📚 **DOCUMENTATION**: Comprehensive integration guide

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -212,7 +212,7 @@ The SDK then provides the redirect URI to the web app through supported channels
 
 1. **Preferred (`setConfig`)** — Calls:
    `WedgeSDK.setConfig({ completionRedirectUri: "<uri>" })`
-2. **Injected bridge object** — Sets both `window.WedgeSDKiOS` and `window.WedgeSDKIOS` with:
+2. **Injected bridge object** — Sets `window.WedgeSDKIOS` with:
    - `getCompletionRedirectUri(): string`
    - `completionRedirectUri: string`
    - `plaidCompletionRedirectUri: string`
@@ -430,7 +430,7 @@ For questions about implementing the type parameter functionality:
 
 ### Version 1.2.0
 - ✨ **NEW**: Runtime app-specific completion redirect URI resolution (explicit URI, URL scheme, or bundle ID fallback)
-- ✨ **NEW**: Webapp redirect propagation through `WedgeSDK.setConfig`, `window.WedgeSDKiOS/window.WedgeSDKIOS`, and supported URL query params
+- ✨ **NEW**: Webapp redirect propagation through `WedgeSDK.setConfig`, `window.WedgeSDKIOS`, and supported URL query params
 - ✨ **NEW**: Hosted Link completion callback contract maintained via `window.__hostedLinkComplete(...)`
 - 📚 **DOCUMENTATION**: Updated integration guidance for redirect/channel requirements
 

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -201,6 +201,15 @@ WedgePayIOS(
 )
 ```
 
+### Plaid completion redirect URI – webapp config
+
+The iOS SDK passes **`plaidCompletionRedirectUri`** to the webapp so it can use it when initializing and when creating the Plaid Hosted Link:
+
+1. **Query param on initial load** — When the SDK loads the webapp URL, it appends **`plaidCompletionRedirectUri`** to the query string when a callback scheme is configured (bundle ID or `plaidCallbackScheme`). Value is the full redirect URI (e.g. `com.yourapp.id://complete` or `wedge.WedgeExample://complete`). The webapp can read this from the URL and pass it into **setConfig / initializeSDK** as `plaidCompletionRedirectUri` in the config object.
+2. **Injected after load** — The SDK also sets **`window.__wedgePlaidCompletionRedirectUri`** and **`window.__wedgePlaidCallbackScheme`** when the page loads, and includes them in the **iOSReady** event detail. The webapp can use these if it needs the value after load (e.g. to call setConfig with `plaidCompletionRedirectUri`).
+
+If the webapp omits or sends an empty `plaidCompletionRedirectUri`, it may fall back to a legacy default (e.g. `wedge.WedgeExample://plaid-link-complete`). Use the same redirect URI you register with Plaid / your backend.
+
 ### Bridge contract
 
 - The Web SDK posts to the **`openPlaidHostedLink`** script message handler. The handler accepts either a **URL string** (`message.body` as the raw URL) or a **payload object** `{ url: "<hosted_link_url>" }` (or `{ type: "OPEN_PLAID_HOSTED_LINK", url: "..." }`).

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -159,16 +159,86 @@ struct ContentView: View {
 }
 ```
 
+## Plaid Hosted Link (ASWebAuthenticationSession)
+
+When the Web SDK receives a `hosted_link_url` from the backend, the iOS wrapper opens it using **ASWebAuthenticationSession** (not inside the WKWebView). This avoids OAuth return URLs being handled inside the SPA and causing 404s.
+
+### Required iOS configuration
+
+1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `plaidCallbackScheme`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-link-complete`). Your backend should set `completion_redirect_uri` for mobile to that (e.g. `com.yourapp.id://plaid-link-complete`). You can override by passing `plaidCallbackScheme: "custom-scheme"` if needed.
+
+2. **Register the URL scheme** in the app target (**Info → URL Types**). The scheme must match what the backend uses (your bundle ID when using the default, or your custom scheme). Example for bundle ID `com.yourapp.id`:
+
+   ```xml
+   <key>CFBundleURLTypes</key>
+   <array>
+       <dict>
+           <key>CFBundleURLSchemes</key>
+           <array>
+               <string>com.yourapp.id</string>
+           </array>
+           <key>CFBundleURLName</key>
+           <string>Plaid Hosted Link callback</string>
+           <key>CFBundleTypeRole</key>
+           <string>Editor</string>
+       </dict>
+   </array>
+   ```
+
+### Usage
+
+```swift
+WedgePayIOS(
+    token: "your-token",
+    env: "sandbox",
+    type: "onboarding",
+    // plaidCallbackScheme: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
+    onEvent: { _ in },
+    onSuccess: { _ in },
+    onClose: { _ in },
+    onLoad: { _ in },
+    onError: { _ in }
+)
+```
+
+### Bridge contract
+
+- The Web SDK posts to the **`openPlaidHostedLink`** script message handler. The handler accepts either a **URL string** (`message.body` as the raw URL) or a **payload object** `{ url: "<hosted_link_url>" }` (or `{ type: "OPEN_PLAID_HOSTED_LINK", url: "..." }`).
+- The iOS SDK opens that URL in **ASWebAuthenticationSession** (with `callbackURLScheme` and a presentation context). The session is retained until the callback runs.
+- When Plaid redirects to your app (e.g. `myapp-plaid://complete?...`) or the user cancels, the iOS SDK calls **`window.__plaidHostedLinkComplete(result)`** (no webview reload). Result:
+  - `result.status`: `"success"` or `"cancel"`
+  - `result.callbackUrl`: the redirect URL on success (optional string).
+
+The Web SDK is responsible for registering `window.__plaidHostedLinkComplete` and refreshing backend state on success or showing cancel/error UI on cancel.
+
+**How the SDK does it:** The SDK’s coordinator conforms to **WKScriptMessageHandler**, registers the **`openPlaidHostedLink`** handler when creating the WKWebView, and keeps a strong reference to the **ASWebAuthenticationSession** until the callback runs. It does **not** reload the webview after Plaid redirects; it notifies the web app via `__plaidHostedLinkComplete` so the web app can continue without a full page reload. If you implement your own view controller instead of using `WedgePayIOS`, you can either use the same callback contract or, after Plaid redirects, reload the webview with your current onboarding URL (the same base URL you load in the webview) so the web app can continue.
+
+### Rules
+
+- Do **not** open `hosted_link_url` inside the WKWebView.
+- Always use **ASWebAuthenticationSession** for the Hosted Link URL.
+- The session is retained until completion; concurrent `OPEN_PLAID_HOSTED_LINK` calls are ignored while a session is active.
+
+### Common issues
+
+| Issue | Check |
+|-------|--------|
+| Callback never fires | Scheme in Info.plist and `plaidCallbackScheme` match backend `completion_redirect_uri`; session is not released early. |
+| 404 / SPA reload | Hosted Link was opened in WKWebView; ensure only the native bridge opens it in ASWebAuthenticationSession. |
+| Multiple sessions | SDK blocks concurrent Hosted Link opens; wait for completion before opening again. |
+
+---
+
 ### API Reference
 
 #### WedgePayIOS Initializer
 
 ```swift
 public init(
-    shouldDismiss: Bool = false,
     token: String,
     env: String,
-    type: String = "onboarding", // New parameter
+    type: String = "onboarding",
+    plaidCallbackScheme: String? = nil,
     onEvent: @escaping (Any) -> Void,
     onSuccess: @escaping (String) -> Void,
     onClose: @escaping (Any) -> Void,
@@ -182,8 +252,9 @@ public init(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `token` | String | Required | Your onboarding token |
-| `env` | String | Required | Environment ("integration", "sandbox", "production") |
+| `env` | String | Required | Environment ("development", "integration", "sandbox", "production") |
 | `type` | String | "onboarding" | Flow type ("onboarding" or "funding") |
+| `plaidCallbackScheme` | String? | nil | If set, used as the Plaid callback URL scheme. If nil, the app’s **bundle identifier** is used (e.g. `com.yourapp.id://complete`). |
 | `onEvent` | Closure | Required | General event handler |
 | `onSuccess` | Closure | Required | Success completion handler |
 | `onClose` | Closure | Required | Close/cancel handler |
@@ -229,6 +300,11 @@ WedgePayIOS(
 ### Test URLs
 
 Use these test URLs to verify the type parameter functionality:
+
+#### Development Environment (local)
+- Base URL: `http://localhost:3000` (same query format as other environments)
+- Onboarding: `http://localhost:3000?onboardingToken=test&type=onboarding`
+- Funding: `http://localhost:3000?onboardingToken=test&type=funding`
 
 #### Integration Environment
 - Onboarding: `https://onboarding-integration.wedge-can.com?onboardingToken=test&type=onboarding`
@@ -331,6 +407,7 @@ For questions about implementing the type parameter functionality:
 ### Version 1.1.0
 - ✨ **NEW**: Added `type` parameter support
 - ✨ **NEW**: Support for "onboarding" and "funding" flow types
+- ✨ **NEW**: Plaid Hosted Link via ASWebAuthenticationSession (`plaidCallbackScheme`)
 - 🔄 **ENHANCED**: URL construction includes type parameter
 - ✅ **BACKWARD COMPATIBLE**: Existing code continues to work
 - 📚 **DOCUMENTATION**: Comprehensive integration guide

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -71,6 +71,7 @@ WedgePayIOS(
     token: "your-onboarding-token",
     env: "sandbox",
     type: "onboarding", // Full onboarding flow
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     onEvent: { event in
         print("Event: \(event)")
     },
@@ -93,6 +94,7 @@ WedgePayIOS(
     token: "your-onboarding-token",
     env: "sandbox",
     type: "funding", // Funding-focused flow
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     onEvent: { event in
         print("Event: \(event)")
     },
@@ -136,6 +138,7 @@ struct ContentView: View {
                 token: "your-token",
                 env: "sandbox",
                 type: userType, // Dynamic type selection
+                hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
                 onEvent: { event in
                     print("Event: \(event)")
                 },
@@ -165,7 +168,7 @@ When the Web SDK receives a `hosted_link_url` from the backend, the iOS wrapper 
 
 ### Required iOS configuration
 
-1. **Callback scheme** — Use your **app’s bundle identifier** as the Plaid completion redirect (recommended). If you omit `hostedLinkRedirectUri`, the SDK uses `Bundle.main.bundleIdentifier` (e.g. `com.yourapp.id` → `com.yourapp.id://plaid-complete`). Your backend should send that same value in the API payload field `completion_redirect_uri` (e.g. `com.yourapp.id://plaid-complete`). You can override by passing `hostedLinkRedirectUri: "custom-scheme"` if needed.
+1. **Callback scheme** — Set `hostedLinkRedirectUri` explicitly to your app callback URI (recommended format: `<bundle-id>://plaid-complete`, e.g. `com.yourapp.id://plaid-complete`). Your backend should send that same value in the API payload field `completion_redirect_uri`.
 
 2. **Register the URL scheme** in the app target (**Info → URL Types**). The scheme must match what the backend uses (your bundle ID when using the default, or your custom scheme). Example for bundle ID `com.yourapp.id`:
 
@@ -192,7 +195,7 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding",
-    // hostedLinkRedirectUri: omit to use the app's bundle ID (e.g. com.yourapp.id://complete)
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     onEvent: { _ in },
     onSuccess: { _ in },
     onClose: { _ in },
@@ -203,10 +206,7 @@ WedgePayIOS(
 
 ### Plaid completion redirect URI – webapp config
 
-The iOS SDK builds an app-specific redirect URI at runtime:
-- If provided, uses `hostedLinkRedirectUri`.
-- Otherwise uses the first URL scheme registered in `CFBundleURLTypes`.
-- If unavailable, falls back to `Bundle.main.bundleIdentifier://plaid-complete`.
+The iOS SDK uses the provided `hostedLinkRedirectUri` directly.
 
 The SDK then provides the redirect URI and Hosted Link capabilities to the web app through supported channels:
 
@@ -264,7 +264,7 @@ public init(
     token: String,
     env: String,
     type: String = "onboarding",
-    hostedLinkRedirectUri: String? = nil,
+    hostedLinkRedirectUri: String,
     onEvent: @escaping (Any) -> Void,
     onSuccess: @escaping (String) -> Void,
     onClose: @escaping (Any) -> Void,
@@ -280,7 +280,7 @@ public init(
 | `token` | String | Required | Your onboarding token |
 | `env` | String | Required | Environment ("development", "integration", "sandbox", "production") |
 | `type` | String | "onboarding" | Flow type ("onboarding" or "funding") |
-| `hostedLinkRedirectUri` | String? | nil | If set, used as the full redirect URI. If nil, SDK derives it from app URL scheme (`CFBundleURLTypes`) and falls back to bundle identifier, then appends `://plaid-complete`. |
+| `hostedLinkRedirectUri` | String | Required | App callback redirect URI used for hosted link completion (for example `com.yourapp.id://plaid-complete`). |
 | `onEvent` | Closure | Required | General event handler |
 | `onSuccess` | Closure | Required | Success completion handler |
 | `onClose` | Closure | Required | Close/cancel handler |
@@ -291,14 +291,15 @@ public init(
 
 ### Existing Code
 
-**All existing implementations continue to work without changes.** The `type` parameter defaults to `"onboarding"`, maintaining the current behavior for existing code.
+`type` continues to default to `"onboarding"`, but `hostedLinkRedirectUri` is now required.
 
 ```swift
-// This existing code continues to work exactly as before
+// Include hostedLinkRedirectUri when initializing the SDK
 WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     // type defaults to "onboarding"
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     onEvent: { event in ... },
     onSuccess: { customerId in ... },
     onClose: { _ in ... },
@@ -311,9 +312,9 @@ WedgePayIOS(
 
 #### For Existing SDKs
 
-1. **No immediate action required** - existing code continues to work
-2. **Optional enhancement** - add type parameter when ready
-3. **Gradual rollout** - implement type selection based on user context
+1. **Add `hostedLinkRedirectUri`** to all initializations
+2. **Keep current type behavior** - `type` remains optional and defaults to `"onboarding"`
+3. **Roll out by user context** - implement type selection when needed
 
 #### For New SDKs
 
@@ -431,7 +432,7 @@ For questions about implementing the type parameter functionality:
 ## Changelog
 
 ### Version 1.2.0
-- ✨ **NEW**: Runtime app-specific completion redirect URI resolution (explicit URI, URL scheme, or bundle ID fallback)
+- ✨ **NEW**: Hosted Link redirect URI propagation via required `hostedLinkRedirectUri`
 - ✨ **NEW**: Webapp redirect propagation through `WedgeSDK.setConfig`, `window.WedgeSDKIOS`, and supported URL query params
 - ✨ **NEW**: Hosted Link completion callback contract maintained via `window.__hostedLinkComplete(...)`
 - 📚 **DOCUMENTATION**: Updated integration guidance for redirect/channel requirements

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -212,21 +212,21 @@ If the webapp omits or sends an empty `plaidCompletionRedirectUri`, it may fall 
 
 ### Bridge contract
 
-- The Web SDK posts to the **`openPlaidHostedLink`** script message handler. The handler accepts either a **URL string** (`message.body` as the raw URL) or a **payload object** `{ url: "<hosted_link_url>" }` (or `{ type: "OPEN_PLAID_HOSTED_LINK", url: "..." }`).
+- The Web SDK posts to the **`openHostedLink`** script message handler. The handler accepts either a **URL string** (`message.body` as the raw URL) or a **payload object** `{ url: "<hosted_link_url>" }` (or `{ type: "OPEN_HOSTED_LINK", url: "..." }`).
 - The iOS SDK opens that URL in **ASWebAuthenticationSession** (with `callbackURLScheme` and a presentation context). The session is retained until the callback runs.
-- When Plaid redirects to your app (e.g. `myapp-plaid://complete?...`) or the user cancels, the iOS SDK calls **`window.__plaidHostedLinkComplete(result)`** (no webview reload). Result:
+- When the provider redirects to your app (e.g. `myapp-plaid://complete?...`) or the user cancels, the iOS SDK calls **`window.__hostedLinkComplete(result)`** (no webview reload). Result:
   - `result.status`: `"success"` or `"cancel"`
   - `result.callbackUrl`: the redirect URL on success (optional string).
 
-The Web SDK is responsible for registering `window.__plaidHostedLinkComplete` and refreshing backend state on success or showing cancel/error UI on cancel.
+The Web SDK is responsible for registering `window.__hostedLinkComplete` and refreshing backend state on success or showing cancel/error UI on cancel.
 
-**How the SDK does it:** The SDK’s coordinator conforms to **WKScriptMessageHandler**, registers the **`openPlaidHostedLink`** handler when creating the WKWebView, and keeps a strong reference to the **ASWebAuthenticationSession** until the callback runs. It does **not** reload the webview after Plaid redirects; it notifies the web app via `__plaidHostedLinkComplete` so the web app can continue without a full page reload. If you implement your own view controller instead of using `WedgePayIOS`, you can either use the same callback contract or, after Plaid redirects, reload the webview with your current onboarding URL (the same base URL you load in the webview) so the web app can continue.
+**How the SDK does it:** The SDK’s coordinator conforms to **WKScriptMessageHandler**, registers the **`openHostedLink`** handler when creating the WKWebView, and keeps a strong reference to the **ASWebAuthenticationSession** until the callback runs. It does **not** reload the webview after the provider redirects; it notifies the web app via `__hostedLinkComplete` so the web app can continue without a full page reload. If you implement your own view controller instead of using `WedgePayIOS`, you can either use the same callback contract or, after redirects, reload the webview with your current onboarding URL (the same base URL you load in the webview) so the web app can continue.
 
 ### Rules
 
 - Do **not** open `hosted_link_url` inside the WKWebView.
 - Always use **ASWebAuthenticationSession** for the Hosted Link URL.
-- The session is retained until completion; concurrent `OPEN_PLAID_HOSTED_LINK` calls are ignored while a session is active.
+- The session is retained until completion; concurrent `openHostedLink` calls are ignored while a session is active.
 
 ### Common issues
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ A SwiftUI SDK that wraps the Wedge onboarding webapp inside a native iOS drawer 
 
 - 🎯 **Native SwiftUI Integration**: Built with SwiftUI and UIViewRepresentable for modern iOS apps
 - 🔄 **Bidirectional Communication**: Real-time messaging between the webapp and native SDK
-- ⚙️ **Configurable**: Support for integration, sandbox, and production environments
+- ⚙️ **Configurable**: Support for development (localhost), integration, sandbox, and production environments
 - 🎨 **Modern UI**: Clean, native iOS design with smooth animations
 - 📱 **iOS 14+ Support**: Built for modern iOS applications
 - 🔒 **Security**: HTTPS-only navigation, input validation, and secure communication
 - ♿ **Accessibility**: Full VoiceOver support and accessibility labels
 - 🔄 **Error Handling**: Comprehensive error handling with retry mechanisms
 - 🧹 **Memory Management**: Proper cleanup and memory leak prevention
+- 🔗 **Plaid Hosted Link**: Opens Plaid Hosted Link in ASWebAuthenticationSession (not in WKWebView) when `plaidCallbackScheme` is set; avoids OAuth 404s and notifies the Web SDK on completion
 
 ## Type Parameter Functionality
 
@@ -47,6 +48,15 @@ WedgePayIOS(
     token: "your-token", 
     env: "sandbox",
     type: "funding", // Funding-focused flow
+    // ... other parameters
+)
+
+// With Plaid Hosted Link (custom URL scheme must be in Info.plist)
+WedgePayIOS(
+    token: "your-token",
+    env: "sandbox",
+    type: "onboarding",
+    plaidCallbackScheme: "myapp-plaid",
     // ... other parameters
 )
 ```
@@ -103,7 +113,7 @@ import WedgePayIOS
 ```swift
 WedgePayIOS(
     token: "your-onboarding-token",
-    env: "sandbox", // or "integration", "production"
+    env: "sandbox", // or "development", "integration", "production"
     type: "onboarding", // or "funding" for changes to linked bank accounts
     onEvent: { event in
         // Handle general events
@@ -183,7 +193,7 @@ The repository includes a complete example project (`WedgeExample/`) that demons
 - **SDK Integration**: How to import and use the `WedgePayIOS` component
 - **Callback Handling**: Examples of all SDK callbacks (onSuccess, onError, onClose, etc.)
 - **Error Handling**: Comprehensive error handling and user feedback
-- **Environment Switching**: Support for sandbox and production environments
+- **Environment Switching**: Support for development (localhost), sandbox, and production environments
 
 To run the example:
 1. Open `WedgeExample/WedgeExample.xcodeproj` in Xcode
@@ -218,7 +228,7 @@ public struct WedgePayIOS: UIViewRepresentable {
 ### Parameters
 
 - `token`: Your onboarding token
-- `env`: Environment ("integration", "sandbox", "production")
+- `env`: Environment ("development", "integration", "sandbox", "production")
 - `type`: Flow type ("onboarding" for new users, "funding" for existing user bank adjustments)
 - `onEvent`: Called for general events
 - `onSuccess`: Called when onboarding completes successfully
@@ -230,9 +240,10 @@ public struct WedgePayIOS: UIViewRepresentable {
 
 ```swift
 var environments = [
+    "development": "http://localhost:3000",
     "integration": "https://onboarding-integration.wedge-can.com",
     "sandbox": "https://onboarding-sandbox.wedge-can.com",
-    "production": "https://onboarding.wedge-can.com"
+    "production": "https://onboarding-production.wedge-can.com"
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,25 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding",
-    completionRedirectUri: "myapp://plaid-link-complete",
+    hostedLinkRedirectUri: "myapp://plaid-complete",
     // ... other parameters
 )
 ```
+
+### Hosted Link Native Contract
+
+When initializing web SDK config, the native wrapper sends:
+
+- `platform: "ios"`
+- `supportsHostedLink: true`
+- `hostedLinkRedirectUri: "<your-callback-uri>"`
+
+The iOS bridge also exposes:
+
+- `getHostedLinkRedirectUri()`
+- `hostedLinkRedirectUri`
+
+`completion_redirect_uri` remains unchanged in backend API payloads.
 
 ### Backward Compatibility
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A SwiftUI SDK that wraps the Wedge onboarding webapp inside a native iOS drawer component with bidirectional communication capabilities.
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 
 ## Features
 
@@ -15,7 +15,7 @@ A SwiftUI SDK that wraps the Wedge onboarding webapp inside a native iOS drawer 
 - ♿ **Accessibility**: Full VoiceOver support and accessibility labels
 - 🔄 **Error Handling**: Comprehensive error handling with retry mechanisms
 - 🧹 **Memory Management**: Proper cleanup and memory leak prevention
-- 🔗 **Plaid Hosted Link**: Opens Plaid Hosted Link in ASWebAuthenticationSession (not in WKWebView) when `plaidCallbackScheme` is set; avoids OAuth 404s and notifies the Web SDK on completion
+- 🔗 **Plaid Hosted Link**: Opens Hosted Link in ASWebAuthenticationSession (not WKWebView), derives app-specific redirect URI at runtime, and notifies webapp via `window.__hostedLinkComplete(...)`
 
 ## Type Parameter Functionality
 
@@ -56,7 +56,7 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding",
-    plaidCallbackScheme: "myapp-plaid",
+    completionRedirectUri: "myapp://plaid-link-complete",
     // ... other parameters
 )
 ```
@@ -89,7 +89,7 @@ Add the following dependency to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/wedge-operations/wedge-pay-ios.git", exact: "1.1.0")
+    .package(url: "https://github.com/wedge-operations/wedge-pay-ios.git", exact: "1.2.0")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A SwiftUI SDK that wraps the Wedge onboarding webapp inside a native iOS drawer 
 - ♿ **Accessibility**: Full VoiceOver support and accessibility labels
 - 🔄 **Error Handling**: Comprehensive error handling with retry mechanisms
 - 🧹 **Memory Management**: Proper cleanup and memory leak prevention
-- 🔗 **Plaid Hosted Link**: Opens Hosted Link in ASWebAuthenticationSession (not WKWebView), derives app-specific redirect URI at runtime, and notifies webapp via `window.__hostedLinkComplete(...)`
+- 🔗 **Plaid Hosted Link**: Opens Hosted Link in ASWebAuthenticationSession (not WKWebView), uses explicit `hostedLinkRedirectUri`, and notifies webapp via `window.__hostedLinkComplete(...)`
 
 ## Type Parameter Functionality
 
@@ -40,6 +40,7 @@ WedgePayIOS(
     token: "your-token",
     env: "sandbox",
     type: "onboarding", // Full onboarding flow
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     // ... other parameters
 )
 
@@ -48,6 +49,7 @@ WedgePayIOS(
     token: "your-token", 
     env: "sandbox",
     type: "funding", // Funding-focused flow
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     // ... other parameters
 )
 
@@ -78,9 +80,9 @@ The iOS bridge also exposes:
 
 ### Backward Compatibility
 
-- Existing code continues to work without changes
+- Existing integrations must pass `hostedLinkRedirectUri`
 - `type` parameter defaults to `"onboarding"` if not specified
-- No breaking changes to existing implementations
+- `hostedLinkRedirectUri` is required for Hosted Link flows
 
 ## Installation
 
@@ -130,6 +132,7 @@ WedgePayIOS(
     token: "your-onboarding-token",
     env: "sandbox", // or "development", "integration", "production"
     type: "onboarding", // or "funding" for changes to linked bank accounts
+    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
     onEvent: { event in
         // Handle general events
         print("Event: \(event)")
@@ -176,6 +179,7 @@ struct ContentView: View {
                     token: "your-onboarding-token-here",
                     env: "sandbox",
                     type: "onboarding", // or "funding" for changes to linked bank accounts
+                    hostedLinkRedirectUri: "com.yourapp.id://plaid-complete",
                     onEvent: { event in
                         print("Event: \(event)")
                     },
@@ -227,10 +231,10 @@ Main SwiftUI view for the SDK.
 ```swift
 public struct WedgePayIOS: UIViewRepresentable {
     public init(
-        shouldDismiss: Bool = false,
         token: String,
         env: String,
         type: String = "onboarding",
+        hostedLinkRedirectUri: String,
         onEvent: @escaping (Any) -> Void,
         onSuccess: @escaping (String) -> Void,
         onClose: @escaping (Any) -> Void,
@@ -245,6 +249,7 @@ public struct WedgePayIOS: UIViewRepresentable {
 - `token`: Your onboarding token
 - `env`: Environment ("development", "integration", "sandbox", "production")
 - `type`: Flow type ("onboarding" for new users, "funding" for existing user bank adjustments)
+- `hostedLinkRedirectUri`: Redirect URI for Hosted Link completion (for example `com.yourapp.id://plaid-complete`)
 - `onEvent`: Called for general events
 - `onSuccess`: Called when onboarding completes successfully
 - `onClose`: Called when user closes/cancels

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -15,10 +15,10 @@ var environments = [
 ]
 
 #if os(iOS) && canImport(AuthenticationServices)
-/// Coordinates opening Plaid Hosted Link in ASWebAuthenticationSession and notifying the Web SDK on completion.
+/// Coordinates opening a provider Hosted Link in ASWebAuthenticationSession and notifying the Web SDK on completion.
 /// The session is strongly retained until completion to prevent early deallocation.
 @available(iOS 12.0, *)
-final class PlaidHostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
+final class HostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
     private var session: ASWebAuthenticationSession?
     private weak var webView: WKWebView?
     private let callbackScheme: String
@@ -74,8 +74,8 @@ final class PlaidHostedLinkCoordinator: NSObject, ASWebAuthenticationPresentatio
 
         let js = """
         (function() {
-            if (window.__plaidHostedLinkComplete) {
-                window.__plaidHostedLinkComplete({
+            if (window.__hostedLinkComplete) {
+                window.__hostedLinkComplete({
                     status: "\(status)",
                     callbackUrl: "\(safeCallback)"
                 });
@@ -179,11 +179,11 @@ public struct WedgePayIOS: UIViewRepresentable {
         webView.configuration.userContentController.add(coordinator, name: "onEvent")
         webView.configuration.userContentController.add(coordinator, name: "onError")
         webView.configuration.userContentController.add(coordinator, name: "onSuccess")
-        webView.configuration.userContentController.add(coordinator, name: "openPlaidHostedLink")
+        webView.configuration.userContentController.add(coordinator, name: "openHostedLink")
 
         coordinator.webView = webView
         if let scheme = effectivePlaidCallbackScheme, #available(iOS 12.0, *) {
-            coordinator.plaidHostedLinkCoordinator = PlaidHostedLinkCoordinator(webView: webView, callbackScheme: scheme)
+            coordinator.hostedLinkCoordinator = HostedLinkCoordinator(webView: webView, callbackScheme: scheme)
         }
 
         // Build initial URL and optional plaidCompletionRedirectUri for webapp config
@@ -244,7 +244,7 @@ public struct WedgePayIOS: UIViewRepresentable {
 
         var wrapper: WedgePayIOS
         weak var webView: WKWebView?
-        var plaidHostedLinkCoordinator: PlaidHostedLinkCoordinator?
+        var hostedLinkCoordinator: HostedLinkCoordinator?
 
         init(wrapper: WedgePayIOS) {
             self.wrapper = wrapper
@@ -271,8 +271,8 @@ public struct WedgePayIOS: UIViewRepresentable {
             case "onClose":
                 wrapper.onClose("Closed")
 
-            case "openPlaidHostedLink":
-                handleOpenPlaidHostedLink(message.body)
+            case "openHostedLink":
+                handleOpenHostedLink(message.body)
 
             case "logHandler":
                 // Optional: forward logs for debugging
@@ -284,9 +284,9 @@ public struct WedgePayIOS: UIViewRepresentable {
             }
         }
 
-        private func handleOpenPlaidHostedLink(_ body: Any) {
-            guard let coordinator = plaidHostedLinkCoordinator else {
-                // print("openPlaidHostedLink received but plaidHostedLinkCoordinator is nil. Did you set plaidCallbackScheme?")
+        private func handleOpenHostedLink(_ body: Any) {
+            guard let coordinator = hostedLinkCoordinator else {
+                // print("openHostedLink received but hostedLinkCoordinator is nil. Did you set plaidCallbackScheme?")
                 return
             }
 
@@ -306,7 +306,7 @@ public struct WedgePayIOS: UIViewRepresentable {
         // MARK: - Navigation Policy
 
         /// IMPORTANT:
-        /// If the Plaid completion redirect (custom scheme) ever attempts to load in WKWebView, cancel it.
+        /// If the Hosted Link completion redirect (custom scheme) ever attempts to load in WKWebView, cancel it.
         /// The completion should be intercepted by ASWebAuthenticationSession instead.
         public func webView(_ webView: WKWebView,
                             decidePolicyFor navigationAction: WKNavigationAction,

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import WebKit
+import UIKit
 #if canImport(AuthenticationServices)
 import AuthenticationServices
 #endif
 
-// SDK Version
-public let WEDGE_PAY_IOS_VERSION = "1.1.0"
+public let WEDGE_PAY_IOS_VERSION = "1.2.0"
 
-var environments = [
+private let environments: [String: String] = [
     "development": "http://localhost:3000",
     "integration": "https://onboarding-integration.wedge-can.com",
     "sandbox": "https://onboarding-sandbox.wedge-can.com",
@@ -15,8 +15,6 @@ var environments = [
 ]
 
 #if os(iOS) && canImport(AuthenticationServices)
-/// Coordinates opening a provider Hosted Link in ASWebAuthenticationSession and notifying the Web SDK on completion.
-/// The session is strongly retained until completion to prevent early deallocation.
 @available(iOS 12.0, *)
 final class HostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
     private var session: ASWebAuthenticationSession?
@@ -28,60 +26,62 @@ final class HostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationCont
         self.callbackScheme = callbackScheme
     }
 
-    /// Opens the Hosted Link URL in ASWebAuthenticationSession. Ignores concurrent calls while a session is active.
     func open(hostedLinkURL: URL) {
         guard session == nil else { return }
 
-        let s = ASWebAuthenticationSession(
+        let authSession = ASWebAuthenticationSession(
             url: hostedLinkURL,
             callbackURLScheme: callbackScheme
-        ) { [weak self] callbackURL, error in
-            guard let self = self else { return }
+        ) { [weak self] callbackURL, _ in
+            guard let self else { return }
 
-            // Helpful debugging during integration
-            // print("ASWebAuthenticationSession finished callbackURL:", callbackURL?.absoluteString ?? "nil",
-            //       "error:", error?.localizedDescription ?? "nil")
-
-            if let callbackURL = callbackURL {
-                self.notifyWeb(status: "success", callbackURL: callbackURL)
+            if let callbackURL {
+                self.notifyWeb(status: "success", callbackURL: callbackURL.absoluteString)
             } else {
                 self.notifyWeb(status: "cancel", callbackURL: nil)
             }
+
             self.session = nil
         }
 
-        s.presentationContextProvider = self
-        s.prefersEphemeralWebBrowserSession = false
+        authSession.presentationContextProvider = self
+        authSession.prefersEphemeralWebBrowserSession = false
 
-        session = s
-        s.start()
+        session = authSession
+        authSession.start()
     }
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .flatMap { $0.windows }
-            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+            .first(where: { $0.isKeyWindow }) ?? ASPresentationAnchor()
     }
 
-    private func notifyWeb(status: String, callbackURL: URL?) {
-        guard let webView = webView else { return }
+    private func notifyWeb(status: String, callbackURL: String?) {
+        guard let webView else { return }
 
-        let callback = callbackURL?.absoluteString ?? ""
-        let safeCallback = callback
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-
-        let js = """
-        (function() {
-            if (window.__hostedLinkComplete) {
-                window.__hostedLinkComplete({
-                    status: "\(status)",
-                    callbackUrl: "\(safeCallback)"
-                });
-            }
-        })();
-        """
+        let js: String
+        if let callbackURL {
+            let escaped = callbackURL
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            js = """
+            (function() {
+              if (window.__hostedLinkComplete) {
+                window.__hostedLinkComplete({ status: "\(status)", callbackUrl: "\(escaped)" });
+              }
+            })();
+            """
+        } else {
+            js = """
+            (function() {
+              if (window.__hostedLinkComplete) {
+                window.__hostedLinkComplete({ status: "\(status)" });
+              }
+            })();
+            """
+        }
 
         DispatchQueue.main.async {
             webView.evaluateJavaScript(js, completionHandler: nil)
@@ -93,29 +93,22 @@ final class HostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationCont
 #if os(iOS)
 @available(iOS 14.0, *)
 public struct WedgePayIOS: UIViewRepresentable {
-    var token: String
-    var env: String
-    var type: String
-    /// Callback URL scheme for Plaid Hosted Link (e.g. completion_redirect_uri "myapp://complete").
-    /// If nil, the app's **bundle identifier** is used (e.g. "com.yourapp.id" → "com.yourapp.id://complete").
-    var plaidCallbackScheme: String?
+    public var token: String
+    public var env: String
+    public var type: String
+    public var completionRedirectUri: String?
 
-    /// Scheme used for Plaid: plaidCallbackScheme if set, otherwise the app's bundle identifier.
-    var effectivePlaidCallbackScheme: String? {
-        if let s = plaidCallbackScheme, !s.isEmpty { return s }
-        return Bundle.main.bundleIdentifier
-    }
-    var onEvent: (Any) -> ()
-    var onSuccess: (String) -> ()
-    var onClose: (Any) -> ()
-    var onLoad: (Any) -> ()
-    var onError: (Any) -> ()
+    public var onEvent: (Any) -> Void
+    public var onSuccess: (String) -> Void
+    public var onClose: (Any) -> Void
+    public var onLoad: (Any) -> Void
+    public var onError: (Any) -> Void
 
     public init(
         token: String,
         env: String,
         type: String = "onboarding",
-        plaidCallbackScheme: String? = nil,
+        completionRedirectUri: String? = nil,
         onEvent: @escaping (Any) -> Void,
         onSuccess: @escaping (String) -> Void,
         onClose: @escaping (Any) -> Void,
@@ -125,26 +118,41 @@ public struct WedgePayIOS: UIViewRepresentable {
         self.token = token
         self.env = env
         self.type = type
-        self.plaidCallbackScheme = plaidCallbackScheme
+        self.completionRedirectUri = completionRedirectUri
         self.onEvent = onEvent
         self.onSuccess = onSuccess
         self.onClose = onClose
         self.onLoad = onLoad
         self.onError = onError
+
+        precondition(URL(string: resolvedCompletionRedirectUri)?.scheme != nil,
+                     "completionRedirectUri must include a valid URL scheme.")
+    }
+
+    private var resolvedCompletionRedirectUri: String {
+        let explicit = completionRedirectUri?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let explicit, !explicit.isEmpty { return explicit }
+
+        if let configuredScheme = Bundle.main.firstConfiguredURLScheme, !configuredScheme.isEmpty {
+            return "\(configuredScheme)://plaid-link-complete"
+        }
+
+        if let bundleIdentifier = Bundle.main.bundleIdentifier, !bundleIdentifier.isEmpty {
+            return "\(bundleIdentifier)://plaid-link-complete"
+        }
+
+        return "wedge.WedgeExample://plaid-link-complete"
+    }
+
+    private var completionCallbackScheme: String? {
+        URL(string: resolvedCompletionRedirectUri)?.scheme
     }
 
     public func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
-
-        // Configure WebView preferences for iOS 14+
-        if #available(iOS 14.0, *) {
-            let prefs = WKWebpagePreferences()
-            prefs.allowsContentJavaScript = true
-            config.defaultWebpagePreferences = prefs
-        } else {
-            config.preferences.javaScriptEnabled = true
-        }
-
+        let prefs = WKWebpagePreferences()
+        prefs.allowsContentJavaScript = true
+        config.defaultWebpagePreferences = prefs
         config.allowsInlineMediaPlayback = true
         config.mediaTypesRequiringUserActionForPlayback = []
 
@@ -153,95 +161,89 @@ public struct WedgePayIOS: UIViewRepresentable {
         webView.uiDelegate = context.coordinator
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.allowsBackForwardNavigationGestures = true
-        webView.scrollView.contentInsetAdjustmentBehavior = .automatic
-        webView.scrollView.showsVerticalScrollIndicator = true
-        webView.scrollView.showsHorizontalScrollIndicator = true
-        webView.scrollView.bounces = true
-        webView.scrollView.maximumZoomScale = 3.0
-        webView.scrollView.minimumZoomScale = 0.5
-        webView.isUserInteractionEnabled = true
 
-        // Capture console.log output and send to iOS (optional)
-        let source = """
-        (function() {
-            function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); }
-            window.console.log = captureLog;
-        })();
-        """
-        let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-        webView.configuration.userContentController.addUserScript(script)
+        registerBridgeScripts(on: webView)
+        registerMessageHandlers(on: webView, coordinator: context.coordinator)
 
-        // Register bridge handlers
-        webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
-        let coordinator = context.coordinator
-        webView.configuration.userContentController.add(coordinator, name: "onClose")
-        webView.configuration.userContentController.add(coordinator, name: "logHandler")
-        webView.configuration.userContentController.add(coordinator, name: "onEvent")
-        webView.configuration.userContentController.add(coordinator, name: "onError")
-        webView.configuration.userContentController.add(coordinator, name: "onSuccess")
-        webView.configuration.userContentController.add(coordinator, name: "openHostedLink")
-
-        coordinator.webView = webView
-        if let scheme = effectivePlaidCallbackScheme, #available(iOS 12.0, *) {
-            coordinator.hostedLinkCoordinator = HostedLinkCoordinator(webView: webView, callbackScheme: scheme)
+        context.coordinator.webView = webView
+        if let scheme = completionCallbackScheme, #available(iOS 12.0, *) {
+            context.coordinator.hostedLinkCoordinator = HostedLinkCoordinator(
+                webView: webView,
+                callbackScheme: scheme
+            )
         }
 
-        // Build initial URL and optional plaidCompletionRedirectUri for webapp config
-        let completionRedirectUri = effectivePlaidCallbackScheme.map { "\($0)://complete" } ?? ""
-
-        guard let baseUrlString = environments[env] else {
-            print("Error: Environment '\(env)' not found. Available environments: \(environments.keys.joined(separator: ", "))")
-
-            let fallbackUrl = environments["sandbox"]!
-            if var components = URLComponents(string: fallbackUrl) {
-                var items = [
-                    URLQueryItem(name: "onboardingToken", value: token),
-                    URLQueryItem(name: "type", value: type)
-                ]
-                if !completionRedirectUri.isEmpty {
-                    items.append(URLQueryItem(name: "plaidCompletionRedirectUri", value: completionRedirectUri))
-                }
-                components.queryItems = items
-                if let url = components.url {
-                    webView.load(URLRequest(url: url))
-                }
+        guard let baseURL = environments[env], var components = URLComponents(string: baseURL) else {
+            let fallback = environments["sandbox"]!
+            var fallbackComponents = URLComponents(string: fallback)!
+            fallbackComponents.queryItems = queryItems()
+            if let url = fallbackComponents.url {
+                webView.load(URLRequest(url: url))
             }
             return webView
         }
 
-        guard var components = URLComponents(string: baseUrlString) else {
-            print("Error: Invalid base URL for environment '\(env)'")
-            return webView
+        components.queryItems = queryItems()
+        if let url = components.url {
+            webView.load(URLRequest(url: url))
         }
 
-        var queryItems = [
-            URLQueryItem(name: "onboardingToken", value: token),
-            URLQueryItem(name: "type", value: type)
-        ]
-        if !completionRedirectUri.isEmpty {
-            queryItems.append(URLQueryItem(name: "plaidCompletionRedirectUri", value: completionRedirectUri))
-        }
-        components.queryItems = queryItems
-
-        guard let url = components.url else {
-            print("Error: Failed to build URL with token and type")
-            return webView
-        }
-
-        webView.load(URLRequest(url: url))
         return webView
     }
 
-    public func updateUIView(_ uiView: WKWebView, context: Context) {
-        // No updates needed
-    }
+    public func updateUIView(_ uiView: WKWebView, context: Context) {}
 
     public func makeCoordinator() -> Coordinator {
         Coordinator(wrapper: self)
     }
 
-    public class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
+    private func queryItems() -> [URLQueryItem] {
+        [
+            URLQueryItem(name: "onboardingToken", value: token),
+            URLQueryItem(name: "type", value: type),
+            URLQueryItem(name: "completionRedirectUri", value: resolvedCompletionRedirectUri)
+        ]
+    }
 
+    private func registerBridgeScripts(on webView: WKWebView) {
+        let safeRedirect = resolvedCompletionRedirectUri
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script = """
+        (function() {
+          var redirectUri = "\(safeRedirect)";
+          var bridge = {
+            getCompletionRedirectUri: function() { return redirectUri; },
+            completionRedirectUri: redirectUri
+          };
+
+          window.WedgeSDKiOS = bridge;
+          window.WedgeSDKIOS = bridge;
+
+          window.dispatchEvent(new CustomEvent('iOSReady', {
+            detail: { completionRedirectUri: redirectUri }
+          }));
+        })();
+        """
+
+        webView.configuration.userContentController.addUserScript(
+            WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        )
+    }
+
+    private func registerMessageHandlers(on webView: WKWebView, coordinator: Coordinator) {
+        let ucc = webView.configuration.userContentController
+        webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
+
+        ucc.add(coordinator, name: "onClose")
+        ucc.add(coordinator, name: "onEvent")
+        ucc.add(coordinator, name: "onError")
+        ucc.add(coordinator, name: "onSuccess")
+        ucc.add(coordinator, name: "openHostedLink")
+    }
+
+    public final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
         var wrapper: WedgePayIOS
         weak var webView: WKWebView?
         var hostedLinkCoordinator: HostedLinkCoordinator?
@@ -249,8 +251,6 @@ public struct WedgePayIOS: UIViewRepresentable {
         init(wrapper: WedgePayIOS) {
             self.wrapper = wrapper
         }
-
-        // MARK: - JS Bridge
 
         public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
             switch message.name {
@@ -274,21 +274,13 @@ public struct WedgePayIOS: UIViewRepresentable {
             case "openHostedLink":
                 handleOpenHostedLink(message.body)
 
-            case "logHandler":
-                // Optional: forward logs for debugging
-                // print("WEB:", message.body)
-                break
-
             default:
                 break
             }
         }
 
         private func handleOpenHostedLink(_ body: Any) {
-            guard let coordinator = hostedLinkCoordinator else {
-                // print("openHostedLink received but hostedLinkCoordinator is nil. Did you set plaidCallbackScheme?")
-                return
-            }
+            guard let hostedLinkCoordinator else { return }
 
             let urlString: String?
             if let dict = body as? [String: Any] {
@@ -299,21 +291,15 @@ public struct WedgePayIOS: UIViewRepresentable {
                 urlString = nil
             }
 
-            guard let urlString = urlString, !urlString.isEmpty, let url = URL(string: urlString) else { return }
-            coordinator.open(hostedLinkURL: url)
+            guard let raw = urlString, let url = URL(string: raw), !raw.isEmpty else { return }
+            hostedLinkCoordinator.open(hostedLinkURL: url)
         }
 
-        // MARK: - Navigation Policy
-
-        /// IMPORTANT:
-        /// If the Hosted Link completion redirect (custom scheme) ever attempts to load in WKWebView, cancel it.
-        /// The completion should be intercepted by ASWebAuthenticationSession instead.
         public func webView(_ webView: WKWebView,
                             decidePolicyFor navigationAction: WKNavigationAction,
                             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-
             if let url = navigationAction.request.url,
-               let scheme = wrapper.effectivePlaidCallbackScheme,
+               let scheme = wrapper.completionCallbackScheme,
                url.scheme?.lowercased() == scheme.lowercased() {
                 decisionHandler(.cancel)
                 return
@@ -323,67 +309,56 @@ public struct WedgePayIOS: UIViewRepresentable {
         }
 
         public func webView(_ webView: WKWebView,
-                            decidePolicyFor navigationResponse: WKNavigationResponse,
-                            decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
-            decisionHandler(.allow)
-        }
-
-        public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            guard let url = webView.url else { return }
-
-            wrapper.onLoad("\(url)")
-
-            let triggerEventScript = """
-            (function() {
-                var event = new CustomEvent('iOSReady', { detail: 'iOS Ready' });
-                window.dispatchEvent(event);
-            })();
-            """
-            webView.evaluateJavaScript(triggerEventScript) { (_, error) in
-                if let error = error {
-                    print("Error triggering event: \(error)")
-                }
-            }
-        }
-
-        public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            print("WebView navigation failed: \(error.localizedDescription)")
-            wrapper.onError("Navigation failed: \(error.localizedDescription)")
-            wrapper.onClose("navigation_error")
-        }
-
-        public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-            print("WebView provisional navigation failed: \(error.localizedDescription)")
-            wrapper.onError("Provisional navigation failed: \(error.localizedDescription)")
-            wrapper.onClose("provisional_navigation_error")
-        }
-
-        // MARK: - target=_blank / window.open handling
-
-        /// IMPORTANT CHANGE:
-        /// Do NOT punt target=_blank links to Safari. Keep them in the same WKWebView.
-        /// This avoids breaking Hosted Link/OAuth flows and avoids Safari "invalid address" screens.
-        public func webView(_ webView: WKWebView,
                             createWebViewWith configuration: WKWebViewConfiguration,
                             for navigationAction: WKNavigationAction,
                             windowFeatures: WKWindowFeatures) -> WKWebView? {
-
             guard navigationAction.targetFrame == nil,
                   let url = navigationAction.request.url else {
                 return nil
             }
 
-            // Allow certain schemes to open externally
             let scheme = (url.scheme ?? "").lowercased()
             if scheme == "tel" || scheme == "mailto" {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 return nil
             }
 
-            // Otherwise, load inside the same WKWebView
             webView.load(URLRequest(url: url))
             return nil
+        }
+
+        public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard let url = webView.url else { return }
+            wrapper.onLoad(url.absoluteString)
+        }
+
+        public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            wrapper.onError("Navigation failed: \(error.localizedDescription)")
+            wrapper.onClose("navigation_error")
+        }
+
+        public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            wrapper.onError("Provisional navigation failed: \(error.localizedDescription)")
+            wrapper.onClose("provisional_navigation_error")
         }
     }
 }
 #endif
+
+private extension Bundle {
+    var firstConfiguredURLScheme: String? {
+        guard let urlTypes = object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
+            return nil
+        }
+
+        for urlType in urlTypes {
+            if let schemes = urlType["CFBundleURLSchemes"] as? [String],
+               let first = schemes.first,
+               !first.isEmpty {
+                return first
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -1,12 +1,94 @@
 import SwiftUI
 import WebKit
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
 
 // SDK Version
 public let WEDGE_PAY_IOS_VERSION = "1.1.0"
 
-var environments = ["integration": "https://onboarding-integration.wedge-can.com",
-                    "sandbox": "https://onboarding-sandbox.wedge-can.com",
-                    "production": "https://onboarding-production.wedge-can.com"]
+var environments = [
+    "development": "http://localhost:3000",
+    "integration": "https://onboarding-integration.wedge-can.com",
+    "sandbox": "https://onboarding-sandbox.wedge-can.com",
+    "production": "https://onboarding-production.wedge-can.com"
+]
+
+#if os(iOS) && canImport(AuthenticationServices)
+/// Coordinates opening Plaid Hosted Link in ASWebAuthenticationSession and notifying the Web SDK on completion.
+/// The session is strongly retained until completion to prevent early deallocation.
+@available(iOS 12.0, *)
+final class PlaidHostedLinkCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private var session: ASWebAuthenticationSession?
+    private weak var webView: WKWebView?
+    private let callbackScheme: String
+
+    init(webView: WKWebView, callbackScheme: String) {
+        self.webView = webView
+        self.callbackScheme = callbackScheme
+    }
+
+    /// Opens the Hosted Link URL in ASWebAuthenticationSession. Ignores concurrent calls while a session is active.
+    func open(hostedLinkURL: URL) {
+        guard session == nil else { return }
+
+        let s = ASWebAuthenticationSession(
+            url: hostedLinkURL,
+            callbackURLScheme: callbackScheme
+        ) { [weak self] callbackURL, error in
+            guard let self = self else { return }
+
+            // Helpful debugging during integration
+            // print("ASWebAuthenticationSession finished callbackURL:", callbackURL?.absoluteString ?? "nil",
+            //       "error:", error?.localizedDescription ?? "nil")
+
+            if let callbackURL = callbackURL {
+                self.notifyWeb(status: "success", callbackURL: callbackURL)
+            } else {
+                self.notifyWeb(status: "cancel", callbackURL: nil)
+            }
+            self.session = nil
+        }
+
+        s.presentationContextProvider = self
+        s.prefersEphemeralWebBrowserSession = false
+
+        session = s
+        s.start()
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+
+    private func notifyWeb(status: String, callbackURL: URL?) {
+        guard let webView = webView else { return }
+
+        let callback = callbackURL?.absoluteString ?? ""
+        let safeCallback = callback
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        let js = """
+        (function() {
+            if (window.__plaidHostedLinkComplete) {
+                window.__plaidHostedLinkComplete({
+                    status: "\(status)",
+                    callbackUrl: "\(safeCallback)"
+                });
+            }
+        })();
+        """
+
+        DispatchQueue.main.async {
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
+    }
+}
+#endif
 
 #if os(iOS)
 @available(iOS 14.0, *)
@@ -14,26 +96,46 @@ public struct WedgePayIOS: UIViewRepresentable {
     var token: String
     var env: String
     var type: String
+    /// Callback URL scheme for Plaid Hosted Link (e.g. completion_redirect_uri "myapp://complete").
+    /// If nil, the app's **bundle identifier** is used (e.g. "com.yourapp.id" → "com.yourapp.id://complete").
+    var plaidCallbackScheme: String?
+
+    /// Scheme used for Plaid: plaidCallbackScheme if set, otherwise the app's bundle identifier.
+    var effectivePlaidCallbackScheme: String? {
+        if let s = plaidCallbackScheme, !s.isEmpty { return s }
+        return Bundle.main.bundleIdentifier
+    }
     var onEvent: (Any) -> ()
     var onSuccess: (String) -> ()
     var onClose: (Any) -> ()
     var onLoad: (Any) -> ()
     var onError: (Any) -> ()
-    
-    public init(token: String, env: String, type: String = "onboarding", onEvent: @escaping (Any) -> Void, onSuccess: @escaping (String) -> Void, onClose: @escaping (Any) -> Void, onLoad: @escaping (Any) -> Void, onError: @escaping (Any) -> Void) {
+
+    public init(
+        token: String,
+        env: String,
+        type: String = "onboarding",
+        plaidCallbackScheme: String? = nil,
+        onEvent: @escaping (Any) -> Void,
+        onSuccess: @escaping (String) -> Void,
+        onClose: @escaping (Any) -> Void,
+        onLoad: @escaping (Any) -> Void,
+        onError: @escaping (Any) -> Void
+    ) {
         self.token = token
         self.env = env
         self.type = type
+        self.plaidCallbackScheme = plaidCallbackScheme
         self.onEvent = onEvent
         self.onSuccess = onSuccess
         self.onClose = onClose
         self.onLoad = onLoad
         self.onError = onError
     }
-    
+
     public func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
-        
+
         // Configure WebView preferences for iOS 14+
         if #available(iOS 14.0, *) {
             let prefs = WKWebpagePreferences()
@@ -42,151 +144,236 @@ public struct WedgePayIOS: UIViewRepresentable {
         } else {
             config.preferences.javaScriptEnabled = true
         }
-        
-        // Configure WebView to reduce constraint conflicts
+
         config.allowsInlineMediaPlayback = true
         config.mediaTypesRequiringUserActionForPlayback = []
-        
+
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
-        
-        // Disable autoresizing mask to prevent constraint conflicts
         webView.translatesAutoresizingMaskIntoConstraints = false
-        
-        // Configure WebView appearance for page-based navigation
         webView.allowsBackForwardNavigationGestures = true
         webView.scrollView.contentInsetAdjustmentBehavior = .automatic
-        
-        // Show scroll indicators for better UX in page navigation
         webView.scrollView.showsVerticalScrollIndicator = true
         webView.scrollView.showsHorizontalScrollIndicator = true
         webView.scrollView.bounces = true
-        
-        // Allow zoom for better accessibility
         webView.scrollView.maximumZoomScale = 3.0
         webView.scrollView.minimumZoomScale = 0.5
-        
-        // inject JS to capture console.log output and send to iOS
-        let source = "function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); } window.console.log = captureLog;"
-        let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-        webView.configuration.userContentController.addUserScript(script)
-        
-        // register the bridge script that listens for the output
-        webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onClose")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "logHandler")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onEvent")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onError")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onSuccess")
-
-        context.coordinator.webView = webView
-
-        // Configure gesture handling for page-based navigation
-        // Note: Back/forward gestures are handled by the WebView's built-in navigation
         webView.isUserInteractionEnabled = true
 
-        guard let environmentUrl = environments[env] else {
+        // Capture console.log output and send to iOS (optional)
+        let source = """
+        (function() {
+            function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); }
+            window.console.log = captureLog;
+        })();
+        """
+        let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        webView.configuration.userContentController.addUserScript(script)
+
+        // Register bridge handlers
+        webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
+        let coordinator = context.coordinator
+        webView.configuration.userContentController.add(coordinator, name: "onClose")
+        webView.configuration.userContentController.add(coordinator, name: "logHandler")
+        webView.configuration.userContentController.add(coordinator, name: "onEvent")
+        webView.configuration.userContentController.add(coordinator, name: "onError")
+        webView.configuration.userContentController.add(coordinator, name: "onSuccess")
+        webView.configuration.userContentController.add(coordinator, name: "openPlaidHostedLink")
+
+        coordinator.webView = webView
+        if let scheme = effectivePlaidCallbackScheme, #available(iOS 12.0, *) {
+            coordinator.plaidHostedLinkCoordinator = PlaidHostedLinkCoordinator(webView: webView, callbackScheme: scheme)
+        }
+
+        // Load initial URL
+        guard let baseUrlString = environments[env] else {
             print("Error: Environment '\(env)' not found. Available environments: \(environments.keys.joined(separator: ", "))")
-            // Fallback to sandbox if environment is invalid
+
             let fallbackUrl = environments["sandbox"]!
-            let url = URL(string: "\(fallbackUrl)?onboardingToken=\(token)&type=\(type)")
-            let request = URLRequest(url: url!)
-            webView.load(request)
+            if var components = URLComponents(string: fallbackUrl) {
+                components.queryItems = [
+                    URLQueryItem(name: "onboardingToken", value: token),
+                    URLQueryItem(name: "type", value: type)
+                ]
+                if let url = components.url {
+                    webView.load(URLRequest(url: url))
+                }
+            }
             return webView
         }
-        
-        let url = URL(string: "\(environmentUrl)?onboardingToken=\(token)&type=\(type)")
 
-        let request = URLRequest(url: url!)
-        webView.load(request)
+        guard var components = URLComponents(string: baseUrlString) else {
+            print("Error: Invalid base URL for environment '\(env)'")
+            return webView
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "onboardingToken", value: token),
+            URLQueryItem(name: "type", value: type)
+        ]
+
+        guard let url = components.url else {
+            print("Error: Failed to build URL with token and type")
+            return webView
+        }
+
+        webView.load(URLRequest(url: url))
         return webView
     }
-    
+
     public func updateUIView(_ uiView: WKWebView, context: Context) {
-        // No modal-specific updates needed for page-based navigation
+        // No updates needed
     }
-    
+
     public func makeCoordinator() -> Coordinator {
-        return Coordinator(wrapper: self)
+        Coordinator(wrapper: self)
     }
 
     public class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
-        
+
         var wrapper: WedgePayIOS
-        var webView: WKWebView?
-        
+        weak var webView: WKWebView?
+        var plaidHostedLinkCoordinator: PlaidHostedLinkCoordinator?
+
         init(wrapper: WedgePayIOS) {
             self.wrapper = wrapper
         }
-        
+
+        // MARK: - JS Bridge
+
         public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
             switch message.name {
-                case "onError":
-                    wrapper.onError(message.body)
-                    // Automatically trigger onClose when an error occurs to allow SDK exit
-                    wrapper.onClose("error_exit")
-                case "onEvent":
-                    wrapper.onEvent(message.body)
-                case "onSuccess":
-                    if let body = message.body as? String {
-                        wrapper.onSuccess(body)
-                    } else {
-                        wrapper.onSuccess("\(message.body)")
-                    }
-                case "onClose":
-                    wrapper.onClose("Closed")
-                default:
-                    break
+            case "onError":
+                wrapper.onError(message.body)
+                wrapper.onClose("error_exit")
+
+            case "onEvent":
+                wrapper.onEvent(message.body)
+
+            case "onSuccess":
+                if let body = message.body as? String {
+                    wrapper.onSuccess(body)
+                } else {
+                    wrapper.onSuccess("\(message.body)")
+                }
+
+            case "onClose":
+                wrapper.onClose("Closed")
+
+            case "openPlaidHostedLink":
+                handleOpenPlaidHostedLink(message.body)
+
+            case "logHandler":
+                // Optional: forward logs for debugging
+                // print("WEB:", message.body)
+                break
+
+            default:
+                break
             }
         }
-        
-        public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+
+        private func handleOpenPlaidHostedLink(_ body: Any) {
+            guard let coordinator = plaidHostedLinkCoordinator else {
+                // print("openPlaidHostedLink received but plaidHostedLinkCoordinator is nil. Did you set plaidCallbackScheme?")
+                return
+            }
+
+            let urlString: String?
+            if let dict = body as? [String: Any] {
+                urlString = dict["url"] as? String
+            } else if let str = body as? String {
+                urlString = str
+            } else {
+                urlString = nil
+            }
+
+            guard let urlString = urlString, !urlString.isEmpty, let url = URL(string: urlString) else { return }
+            coordinator.open(hostedLinkURL: url)
+        }
+
+        // MARK: - Navigation Policy
+
+        /// IMPORTANT:
+        /// If the Plaid completion redirect (custom scheme) ever attempts to load in WKWebView, cancel it.
+        /// The completion should be intercepted by ASWebAuthenticationSession instead.
+        public func webView(_ webView: WKWebView,
+                            decidePolicyFor navigationAction: WKNavigationAction,
+                            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+            if let url = navigationAction.request.url,
+               let scheme = wrapper.effectivePlaidCallbackScheme,
+               url.scheme?.lowercased() == scheme.lowercased() {
+                decisionHandler(.cancel)
+                return
+            }
+
             decisionHandler(.allow)
         }
-        
+
+        public func webView(_ webView: WKWebView,
+                            decidePolicyFor navigationResponse: WKNavigationResponse,
+                            decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+            decisionHandler(.allow)
+        }
+
         public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             guard let url = webView.url else { return }
-            
+
             wrapper.onLoad("\(url)")
-            
+
             let triggerEventScript = """
+            (function() {
                 var event = new CustomEvent('iOSReady', { detail: 'iOS Ready' });
                 window.dispatchEvent(event);
+            })();
             """
-            webView.evaluateJavaScript(triggerEventScript) { (result, error) in
+            webView.evaluateJavaScript(triggerEventScript) { (_, error) in
                 if let error = error {
                     print("Error triggering event: \(error)")
-                } else {
-                    print("Event triggered successfully")
                 }
             }
         }
-        
+
         public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
             print("WebView navigation failed: \(error.localizedDescription)")
             wrapper.onError("Navigation failed: \(error.localizedDescription)")
-            // Allow SDK exit on navigation failure
             wrapper.onClose("navigation_error")
         }
-        
+
         public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
             print("WebView provisional navigation failed: \(error.localizedDescription)")
             wrapper.onError("Provisional navigation failed: \(error.localizedDescription)")
-            // Allow SDK exit on provisional navigation failure
             wrapper.onClose("provisional_navigation_error")
         }
-        
-        public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-            if let url = navigationAction.request.url {
-                if navigationAction.targetFrame == nil {
-                    if UIApplication.shared.canOpenURL(url) {
-                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                    }
-                }
+
+        // MARK: - target=_blank / window.open handling
+
+        /// IMPORTANT CHANGE:
+        /// Do NOT punt target=_blank links to Safari. Keep them in the same WKWebView.
+        /// This avoids breaking Hosted Link/OAuth flows and avoids Safari "invalid address" screens.
+        public func webView(_ webView: WKWebView,
+                            createWebViewWith configuration: WKWebViewConfiguration,
+                            for navigationAction: WKNavigationAction,
+                            windowFeatures: WKWindowFeatures) -> WKWebView? {
+
+            guard navigationAction.targetFrame == nil,
+                  let url = navigationAction.request.url else {
+                return nil
             }
+
+            // Allow certain schemes to open externally
+            let scheme = (url.scheme ?? "").lowercased()
+            if scheme == "tel" || scheme == "mailto" {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                return nil
+            }
+
+            // Otherwise, load inside the same WKWebView
+            webView.load(URLRequest(url: url))
             return nil
         }
     }
 }
-#endif 
+#endif

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -96,7 +96,7 @@ public struct WedgePayIOS: UIViewRepresentable {
     public var token: String
     public var env: String
     public var type: String
-    public var completionRedirectUri: String?
+    public var hostedLinkRedirectUri: String?
 
     public var onEvent: (Any) -> Void
     public var onSuccess: (String) -> Void
@@ -108,7 +108,7 @@ public struct WedgePayIOS: UIViewRepresentable {
         token: String,
         env: String,
         type: String = "onboarding",
-        completionRedirectUri: String? = nil,
+        hostedLinkRedirectUri: String? = nil,
         onEvent: @escaping (Any) -> Void,
         onSuccess: @escaping (String) -> Void,
         onClose: @escaping (Any) -> Void,
@@ -118,34 +118,34 @@ public struct WedgePayIOS: UIViewRepresentable {
         self.token = token
         self.env = env
         self.type = type
-        self.completionRedirectUri = completionRedirectUri
+        self.hostedLinkRedirectUri = hostedLinkRedirectUri
         self.onEvent = onEvent
         self.onSuccess = onSuccess
         self.onClose = onClose
         self.onLoad = onLoad
         self.onError = onError
 
-        precondition(URL(string: resolvedCompletionRedirectUri)?.scheme != nil,
-                     "completionRedirectUri must include a valid URL scheme.")
+        precondition(URL(string: resolvedHostedLinkRedirectUri)?.scheme != nil,
+                     "hostedLinkRedirectUri must include a valid URL scheme.")
     }
 
-    private var resolvedCompletionRedirectUri: String {
-        let explicit = completionRedirectUri?.trimmingCharacters(in: .whitespacesAndNewlines)
+    private var resolvedHostedLinkRedirectUri: String {
+        let explicit = hostedLinkRedirectUri?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let explicit, !explicit.isEmpty { return explicit }
 
         if let configuredScheme = Bundle.main.firstConfiguredURLScheme, !configuredScheme.isEmpty {
-            return "\(configuredScheme)://plaid-link-complete"
+            return "\(configuredScheme)://plaid-complete"
         }
 
         if let bundleIdentifier = Bundle.main.bundleIdentifier, !bundleIdentifier.isEmpty {
-            return "\(bundleIdentifier)://plaid-link-complete"
+            return "\(bundleIdentifier)://plaid-complete"
         }
 
-        return "wedge.WedgeExample://plaid-link-complete"
+        return "wedge.WedgeExample://plaid-complete"
     }
 
-    private var completionCallbackScheme: String? {
-        URL(string: resolvedCompletionRedirectUri)?.scheme
+    private var hostedLinkCallbackScheme: String? {
+        URL(string: resolvedHostedLinkRedirectUri)?.scheme
     }
 
     public func makeUIView(context: Context) -> WKWebView {
@@ -166,7 +166,7 @@ public struct WedgePayIOS: UIViewRepresentable {
         registerMessageHandlers(on: webView, coordinator: context.coordinator)
 
         context.coordinator.webView = webView
-        if let scheme = completionCallbackScheme, #available(iOS 12.0, *) {
+        if let scheme = hostedLinkCallbackScheme, #available(iOS 12.0, *) {
             context.coordinator.hostedLinkCoordinator = HostedLinkCoordinator(
                 webView: webView,
                 callbackScheme: scheme
@@ -201,27 +201,60 @@ public struct WedgePayIOS: UIViewRepresentable {
         [
             URLQueryItem(name: "onboardingToken", value: token),
             URLQueryItem(name: "type", value: type),
-            URLQueryItem(name: "completionRedirectUri", value: resolvedCompletionRedirectUri)
+            URLQueryItem(name: "hostedLinkRedirectUri", value: resolvedHostedLinkRedirectUri),
+            URLQueryItem(name: "platform", value: "ios"),
+            URLQueryItem(name: "supportsHostedLink", value: "true")
         ]
     }
 
     private func registerBridgeScripts(on webView: WKWebView) {
-        let safeRedirect = resolvedCompletionRedirectUri
+        let safeRedirect = resolvedHostedLinkRedirectUri
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
 
         let script = """
         (function() {
           var redirectUri = "\(safeRedirect)";
+          var config = {
+            hostedLinkRedirectUri: redirectUri,
+            platform: 'ios',
+            supportsHostedLink: true
+          };
           var bridge = {
-            getCompletionRedirectUri: function() { return redirectUri; },
-            completionRedirectUri: redirectUri
+            getHostedLinkRedirectUri: function() { return redirectUri; },
+            hostedLinkRedirectUri: redirectUri,
+            platform: 'ios',
+            supportsHostedLink: true
           };
 
           window.WedgeSDKIOS = bridge;
 
+          var configApplied = false;
+          var attempts = 0;
+          var maxAttempts = 40;
+          var retryDelayMs = 50;
+
+          function applyConfig() {
+            if (configApplied) return;
+            if (window.WedgeSDK && typeof window.WedgeSDK.setConfig === 'function') {
+              window.WedgeSDK.setConfig(config);
+              configApplied = true;
+              return;
+            }
+            attempts += 1;
+            if (attempts < maxAttempts) {
+              setTimeout(applyConfig, retryDelayMs);
+            }
+          }
+
+          applyConfig();
+
           window.dispatchEvent(new CustomEvent('iOSReady', {
-            detail: { completionRedirectUri: redirectUri }
+            detail: {
+              hostedLinkRedirectUri: redirectUri,
+              platform: 'ios',
+              supportsHostedLink: true
+            }
           }));
         })();
         """
@@ -298,7 +331,7 @@ public struct WedgePayIOS: UIViewRepresentable {
                             decidePolicyFor navigationAction: WKNavigationAction,
                             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             if let url = navigationAction.request.url,
-               let scheme = wrapper.completionCallbackScheme,
+               let scheme = wrapper.hostedLinkCallbackScheme,
                url.scheme?.lowercased() == scheme.lowercased() {
                 decisionHandler(.cancel)
                 return

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -218,7 +218,6 @@ public struct WedgePayIOS: UIViewRepresentable {
             completionRedirectUri: redirectUri
           };
 
-          window.WedgeSDKiOS = bridge;
           window.WedgeSDKIOS = bridge;
 
           window.dispatchEvent(new CustomEvent('iOSReady', {

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -5,6 +5,7 @@ import UIKit
 import AuthenticationServices
 #endif
 
+
 public let WEDGE_PAY_IOS_VERSION = "1.2.0"
 
 private let environments: [String: String] = [
@@ -96,7 +97,7 @@ public struct WedgePayIOS: UIViewRepresentable {
     public var token: String
     public var env: String
     public var type: String
-    public var hostedLinkRedirectUri: String?
+    public var hostedLinkRedirectUri: String
 
     public var onEvent: (Any) -> Void
     public var onSuccess: (String) -> Void
@@ -108,7 +109,7 @@ public struct WedgePayIOS: UIViewRepresentable {
         token: String,
         env: String,
         type: String = "onboarding",
-        hostedLinkRedirectUri: String? = nil,
+        hostedLinkRedirectUri: String,
         onEvent: @escaping (Any) -> Void,
         onSuccess: @escaping (String) -> Void,
         onClose: @escaping (Any) -> Void,
@@ -130,18 +131,7 @@ public struct WedgePayIOS: UIViewRepresentable {
     }
 
     private var resolvedHostedLinkRedirectUri: String {
-        let explicit = hostedLinkRedirectUri?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let explicit, !explicit.isEmpty { return explicit }
-
-        if let configuredScheme = Bundle.main.firstConfiguredURLScheme, !configuredScheme.isEmpty {
-            return "\(configuredScheme)://plaid-complete"
-        }
-
-        if let bundleIdentifier = Bundle.main.bundleIdentifier, !bundleIdentifier.isEmpty {
-            return "\(bundleIdentifier)://plaid-complete"
-        }
-
-        return "wedge.WedgeExample://plaid-complete"
+        hostedLinkRedirectUri.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var hostedLinkCallbackScheme: String? {
@@ -376,21 +366,3 @@ public struct WedgePayIOS: UIViewRepresentable {
     }
 }
 #endif
-
-private extension Bundle {
-    var firstConfiguredURLScheme: String? {
-        guard let urlTypes = object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
-            return nil
-        }
-
-        for urlType in urlTypes {
-            if let schemes = urlType["CFBundleURLSchemes"] as? [String],
-               let first = schemes.first,
-               !first.isEmpty {
-                return first
-            }
-        }
-
-        return nil
-    }
-}

--- a/Sources/wedge_pay_ios/wedge_pay_ios.swift
+++ b/Sources/wedge_pay_ios/wedge_pay_ios.swift
@@ -186,16 +186,22 @@ public struct WedgePayIOS: UIViewRepresentable {
             coordinator.plaidHostedLinkCoordinator = PlaidHostedLinkCoordinator(webView: webView, callbackScheme: scheme)
         }
 
-        // Load initial URL
+        // Build initial URL and optional plaidCompletionRedirectUri for webapp config
+        let completionRedirectUri = effectivePlaidCallbackScheme.map { "\($0)://complete" } ?? ""
+
         guard let baseUrlString = environments[env] else {
             print("Error: Environment '\(env)' not found. Available environments: \(environments.keys.joined(separator: ", "))")
 
             let fallbackUrl = environments["sandbox"]!
             if var components = URLComponents(string: fallbackUrl) {
-                components.queryItems = [
+                var items = [
                     URLQueryItem(name: "onboardingToken", value: token),
                     URLQueryItem(name: "type", value: type)
                 ]
+                if !completionRedirectUri.isEmpty {
+                    items.append(URLQueryItem(name: "plaidCompletionRedirectUri", value: completionRedirectUri))
+                }
+                components.queryItems = items
                 if let url = components.url {
                     webView.load(URLRequest(url: url))
                 }
@@ -208,10 +214,14 @@ public struct WedgePayIOS: UIViewRepresentable {
             return webView
         }
 
-        components.queryItems = [
+        var queryItems = [
             URLQueryItem(name: "onboardingToken", value: token),
             URLQueryItem(name: "type", value: type)
         ]
+        if !completionRedirectUri.isEmpty {
+            queryItems.append(URLQueryItem(name: "plaidCompletionRedirectUri", value: completionRedirectUri))
+        }
+        components.queryItems = queryItems
 
         guard let url = components.url else {
             print("Error: Failed to build URL with token and type")

--- a/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
+++ b/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
@@ -28,6 +28,7 @@ final class WedgePayIOSTests: XCTestCase {
             token: "test-token-123",
             env: "sandbox",
             type: "onboarding",
+            completionRedirectUri: "wedge.WedgeExample://plaid-link-complete",
             onEvent: { event in
                 eventCalled = true
                 XCTAssertNotNil(event)

--- a/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
+++ b/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
@@ -28,7 +28,7 @@ final class WedgePayIOSTests: XCTestCase {
             token: "test-token-123",
             env: "sandbox",
             type: "onboarding",
-            completionRedirectUri: "wedge.WedgeExample://plaid-link-complete",
+            hostedLinkRedirectUri: "wedge.WedgeExample://plaid-complete",
             onEvent: { event in
                 eventCalled = true
                 XCTAssertNotNil(event)

--- a/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
+++ b/Tests/wedge_pay_iosTests/wedge_pay_iosTests.swift
@@ -4,10 +4,12 @@ import XCTest
 final class WedgePayIOSTests: XCTestCase {
     
     func testWedgeEnvironmentURLs() {
-        let environments = ["integration": "https://onboarding-integration.wedge-can.com",
+        let environments = ["development": "http://localhost:3000",
+                           "integration": "https://onboarding-integration.wedge-can.com",
                            "sandbox": "https://onboarding-sandbox.wedge-can.com",
-                           "production": "https://onboarding.wedge-can.com"]
+                           "production": "https://onboarding-production.wedge-can.com"]
         
+        XCTAssertEqual(environments["development"], "http://localhost:3000")
         XCTAssertEqual(environments["integration"], "https://onboarding-integration.wedge-can.com")
         XCTAssertEqual(environments["sandbox"], "https://onboarding-sandbox.wedge-can.com")
         XCTAssertEqual(environments["production"], "https://onboarding-production.wedge-can.com")

--- a/WedgeExample/Info-PlaidURLScheme.plist
+++ b/WedgeExample/Info-PlaidURLScheme.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wedge.WedgeExample</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>Plaid Hosted Link callback (bundle ID as scheme)</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/WedgeExample/README.md
+++ b/WedgeExample/README.md
@@ -27,7 +27,7 @@ Open `WedgeExample.xcodeproj` in Xcode.
 - **Callback Handling**: Examples of all SDK callbacks (onSuccess, onError, onClose, etc.)
 - **Custom Presentation**: Bottom slide transition instead of default side navigation
 - **Error Handling**: Comprehensive error handling and user feedback
-- **Environment Switching**: Support for integration, sandbox, and production environments
+- **Environment Switching**: Support for development (localhost), integration, sandbox, and production environments
 
 ## Type Parameter Functionality
 

--- a/WedgeExample/WedgeExample.xcodeproj/project.pbxproj
+++ b/WedgeExample/WedgeExample.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"WedgeExample/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info-PlaidURLScheme.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -291,6 +292,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"WedgeExample/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info-PlaidURLScheme.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/WedgeExample/WedgeExample/ContentView.swift
+++ b/WedgeExample/WedgeExample/ContentView.swift
@@ -204,9 +204,9 @@ struct OnboardingView: View {
     let onLoad: (Any) -> ()
     let onError: (Any) -> ()
 
-    private var completionRedirectUri: String {
+    private var hostedLinkRedirectUri: String {
         let configuredScheme = Bundle.main.firstConfiguredURLScheme ?? "wedge.WedgeExample"
-        return "\(configuredScheme)://plaid-link-complete"
+        return "\(configuredScheme)://plaid-complete"
     }
     
     var body: some View {
@@ -214,7 +214,7 @@ struct OnboardingView: View {
             token: token,
             env: env,
             type: type,
-            completionRedirectUri: completionRedirectUri,
+            hostedLinkRedirectUri: hostedLinkRedirectUri,
             onEvent: onEvent,
             onSuccess: onSuccess,
             onClose: onClose,

--- a/WedgeExample/WedgeExample/ContentView.swift
+++ b/WedgeExample/WedgeExample/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @State private var alertMessage = ""
     @State private var showingOnboarding = false
     
-    private let environments = ["integration", "sandbox", "production"]
+    private let environments = ["development", "integration", "sandbox", "production"]
     private let types = ["onboarding", "funding"]
     
     var body: some View {
@@ -209,6 +209,7 @@ struct OnboardingView: View {
             token: token,
             env: env,
             type: type,
+            // plaidCallbackScheme: omit to use the app's bundle ID (e.g. wedge.WedgeExample://complete)
             onEvent: onEvent,
             onSuccess: onSuccess,
             onClose: onClose,

--- a/WedgeExample/WedgeExample/ContentView.swift
+++ b/WedgeExample/WedgeExample/ContentView.swift
@@ -203,13 +203,18 @@ struct OnboardingView: View {
     let onClose: (Any) -> ()
     let onLoad: (Any) -> ()
     let onError: (Any) -> ()
+
+    private var completionRedirectUri: String {
+        let configuredScheme = Bundle.main.firstConfiguredURLScheme ?? "wedge.WedgeExample"
+        return "\(configuredScheme)://plaid-link-complete"
+    }
     
     var body: some View {
         WedgePayIOS(
             token: token,
             env: env,
             type: type,
-            // plaidCallbackScheme: omit to use the app's bundle ID (e.g. wedge.WedgeExample://complete)
+            completionRedirectUri: completionRedirectUri,
             onEvent: onEvent,
             onSuccess: onSuccess,
             onClose: onClose,
@@ -224,5 +229,22 @@ struct OnboardingView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+private extension Bundle {
+    var firstConfiguredURLScheme: String? {
+        guard let urlTypes = object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
+            return nil
+        }
+
+        for urlType in urlTypes {
+            if let schemes = urlType["CFBundleURLSchemes"] as? [String],
+               let firstScheme = schemes.first,
+               !firstScheme.isEmpty {
+                return firstScheme
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- Adds runtime app-specific completion redirect URI resolution in the iOS SDK (`completionRedirectUri` explicit value, then app URL scheme, then bundle identifier fallback).
- Exposes the redirect URI to the webapp through all supported channels:
  - `WedgeSDK.setConfig({ completionRedirectUri })` (preferred)
  - `window.WedgeSDKiOS` / `window.WedgeSDKIOS` bridge (`getCompletionRedirectUri`, `completionRedirectUri`, `plaidCompletionRedirectUri`)
  - URL query params (`completionRedirectUri`, `plaidCompletionRedirectUri`, `completion_redirect_uri`, `plaid_completion_redirect_uri`)
- Keeps existing native Hosted Link handling and ensures `window.__hostedLinkComplete(...)` is called after `ASWebAuthenticationSession` success/cancel.